### PR TITLE
Check if file opened correctly

### DIFF
--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -78,6 +78,9 @@ namespace podio {
 
   void ROOTReader::openFile(const std::string& filename){
     m_file = new TFile(filename.c_str(),"READ","data file");
+    if (m_file->IsZombie()) {
+      exit(-1);
+    }
     m_eventTree = static_cast<TTree*>( m_file->Get("events") );
     readCollectionIDTable();
   }


### PR DESCRIPTION
Check if a file opened correctly, and if not - exit.
ROOT prints an error message.