### PR TITLE
fixed extra code generation for ConstObject

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -350,12 +350,21 @@ class ClassGenerator(object):
     constextracode = ""
     if definition.has_key("ExtraCode"):
       extra = definition["ExtraCode"]
-      extracode_declarations = extra["declaration"]
-      extracode = extra["implementation"].replace("{name}",rawclassname)
-      constextracode_declarations = extra["declaration"]
-      constextracode = extra["implementation"].replace("{name}","Const"+rawclassname)
+      if( extra.has_key("declaration")):
+          extracode_declarations = extra["declaration"]
+      if( extra.has_key("implementation")):
+          extracode = extra["implementation"].replace("{name}",rawclassname)
+      if( extra.has_key("const_declaration")):
+          constextracode_declarations = extra["const_declaration"]
+          extracode_declarations += "\n"
+          extracode_declarations += extra["const_declaration"]
+      if( extra.has_key("const_implementation")):
+          constextracode = extra["const_implementation"].replace("{name}","Const"+rawclassname)
+          extracode += "\n"
+          extracode += extra["const_implementation"].replace("{name}",rawclassname)
       # TODO: add loading of code from external files
-      datatype["includes"] += extra["includes"]
+      if( extra.has_key("includes")):
+          datatype["includes"] += extra["includes"]
 
     substitutions = {"includes" : "\n".join(datatype["includes"]),
                      "includes_cc" : includes_cc,

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -30,10 +30,10 @@ datatypes :
     Members :
      - int Number // event number
     ExtraCode :
-       includes: ""
-       declaration: "int getNumber() const;"
-       implementation: "int {name}::getNumber() const { return Number(); }"
-
+       const_declaration: "int getNumber() const; "
+       const_implementation: "int {name}::getNumber() const { return Number(); } "
+       declaration: "void setNumber(int n) { Number( n ) ; } "
+       
   ExampleHit :
     Description : "Example Hit"
     Author : "B. Hegner"

--- a/tests/datamodel/EventInfo.h
+++ b/tests/datamodel/EventInfo.h
@@ -53,7 +53,8 @@ public:
 
 
 
-int getNumber() const;
+void setNumber(int n) { Number( n ) ; } 
+int getNumber() const; 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from EventInfoObj instance

--- a/tests/datamodel/EventInfoConst.h
+++ b/tests/datamodel/EventInfoConst.h
@@ -48,7 +48,7 @@ public:
   const int& Number() const;
 
 
-int getNumber() const;
+int getNumber() const; 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from EventInfoObj instance

--- a/tests/src/EventInfo.cc
+++ b/tests/src/EventInfo.cc
@@ -49,7 +49,8 @@ EventInfo::operator ConstEventInfo() const {return ConstEventInfo(m_obj);}
 void EventInfo::Number(int value){ m_obj->data.Number = value; }
 
 
-int EventInfo::getNumber() const { return Number(); }
+
+int EventInfo::getNumber() const { return Number(); } 
 bool  EventInfo::isAvailable() const {
   if (m_obj != nullptr) {
     return true;

--- a/tests/src/EventInfoConst.cc
+++ b/tests/src/EventInfoConst.cc
@@ -45,7 +45,7 @@ ConstEventInfo::~ConstEventInfo(){
   const int& ConstEventInfo::Number() const { return m_obj->data.Number; }
 
 
-int ConstEventInfo::getNumber() const { return Number(); }
+int ConstEventInfo::getNumber() const { return Number(); } 
 bool  ConstEventInfo::isAvailable() const {
   if (m_obj != nullptr) {
     return true;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -210,7 +210,8 @@ TEST_CASE("Arrays") {
 
 TEST_CASE("Extracode") {
   auto ev = EventInfo();
-  REQUIRE(ev.getNumber() == 0);
+  ev.setNumber(42) ;
+  REQUIRE(ev.getNumber() == 42);
 
   int ia[3] = { 1 , 2 , 3 } ;
   auto simple = SimpleStruct( ia ) ;


### PR DESCRIPTION
 - extra code is now split into const and non-const parts:
   - const_declaration/const_implementation will be added to
     both ConstObject and Object
     declaration and implementation only to Object
     ( needed as otherwise setters would be added to ConstObject ...)
 - neither keyword must be present in the yaml file 
 - added simple test to SimpleStruct and unittest