### PR TITLE
optional get/set syntax; operator<(); acces to reference vector

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -31,12 +31,14 @@ _text_ = """
 
 class ClassGenerator(object):
 
-  def __init__(self,yamlfile, install_dir, package_name, verbose = True):
+  def __init__(self,yamlfile, install_dir, package_name, verbose = True, getSyntax = False ):
+
     self.yamlfile = yamlfile
     self.install_dir = install_dir
     self.package_name =package_name
     self.template_dir = os.path.join(thisdir,"../templates")
     self.verbose=verbose
+    self.getSyntax=getSyntax
     self.buildin_types = ClassDefinitionValidator.buildin_types
     self.created_classes = []
     self.requested_classes = []
@@ -250,18 +252,22 @@ class ClassGenerator(object):
     for member in definition["Members"]:
       name = member["name"]
       klass = member["type"]
-      getter_declarations += declarations["member_getter"].format(type=klass, name=name)
-      getter_implementations += implementations["member_getter"].format(type=klass, classname=rawclassname, name=name)
+      gname,sname = name,name 
+      if( self.getSyntax ):
+        gname = "get" + name[:1].upper() + name[1:]
+        sname = "set" + name[:1].upper() + name[1:]
+      getter_declarations += declarations["member_getter"].format(type=klass, name=name,fname=gname)
+      getter_implementations += implementations["member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
       if klass in self.buildin_types:
-        setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name)
-        setter_implementations += implementations["member_builtin_setter"].format(type=klass, classname=rawclassname, name=name)
+        setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name, fname=sname)
+        setter_implementations += implementations["member_builtin_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
       else:
         setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name)
-        setter_implementations += implementations["member_class_refsetter"].format(type=klass, classname=rawclassname, name=name)
-        setter_declarations += declarations["member_class_setter"].format(type=klass, name=name)
-        setter_implementations += implementations["member_class_setter"].format(type=klass, classname=rawclassname, name=name)
+        setter_implementations += implementations["member_class_refsetter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
+        setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname)
+        setter_implementations += implementations["member_class_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
       # Getter for the Const variety of this datatype
-      ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name)
+      ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
 
 
       # set up signature
@@ -332,9 +338,19 @@ class ClassGenerator(object):
       if relationtype not in self.buildin_types and relationtype not in self.reader.components:
           relationtype = "Const"+relationtype
 
-      substitutions = {"relation" : refvector["name"],
+      relationName = refvector["name"]
+      get_relation = relationName
+      add_relation = "add"+relationName
+
+      if( self.getSyntax ):
+        get_relation = "get" + relationName[:1].upper() + relationName[1:]
+        add_relation = "add" + relationName[:1].upper() + relationName[1:len(relationName)-1]  # drop the 's' at the end !??
+
+      substitutions = {"relation" : relationName,
+                       "get_relation" : get_relation,
+                       "add_relation" : add_relation,
                        "relationtype" : relationtype,
-                       "classname" : rawclassname,
+                       "classname"  : rawclassname,
                        "package_name" : self.package_name
                       }
       references_declarations += string.Template(references_declarations_template).substitute(substitutions)
@@ -351,11 +367,11 @@ class ClassGenerator(object):
     if definition.has_key("ExtraCode"):
       extra = definition["ExtraCode"]
       if( extra.has_key("declaration")):
-          extracode_declarations = extra["declaration"]
+          extracode_declarations = extra["declaration"].replace("{name}",rawclassname)
       if( extra.has_key("implementation")):
           extracode = extra["implementation"].replace("{name}",rawclassname)
       if( extra.has_key("const_declaration")):
-          constextracode_declarations = extra["const_declaration"]
+          constextracode_declarations = extra["const_declaration"].replace("{name}","Const"+rawclassname)
           extracode_declarations += "\n"
           extracode_declarations += extra["const_declaration"]
       if( extra.has_key("const_implementation")):
@@ -364,7 +380,8 @@ class ClassGenerator(object):
           extracode += extra["const_implementation"].replace("{name}",rawclassname)
       # TODO: add loading of code from external files
       if( extra.has_key("includes")):
-          datatype["includes"] += extra["includes"]
+          datatype["includes"].append( extra["includes"] )
+          print " ***** adding includes : " ,  extra["includes"] , "to" ,  datatype["includes"] 
 
     substitutions = {"includes" : "\n".join(datatype["includes"]),
                      "includes_cc" : includes_cc,
@@ -733,6 +750,9 @@ if __name__ == "__main__":
   parser.add_option("-q", "--quiet",
                     action="store_false", dest="verbose", default=True,
                     help="Don't write a report to screen")
+  parser.add_option("-g", "--getSyntax",
+                    action="store_true", dest="getSyntax", default=False,
+                    help="Create getter and setter members with getMember/setMember syntax")
   (options, args) = parser.parse_args()
 
   if len(args) != 3:
@@ -749,7 +769,7 @@ if __name__ == "__main__":
   if not os.path.exists( directory ):
     os.makedirs(directory)
 
-  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose)
+  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose, getSyntax=options.getSyntax )
   gen.process()
   for warning in gen.warnings:
       print warning

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -5,19 +5,19 @@ arguments = {}
 
 # Members
 #-----------------------------------
-declarations["member_getter"] = "\tconst {type}& {name}() const;\n"
-implementations["member_getter"] = "\tconst {type}& {classname}::{name}() const {{ return m_obj->data.{name}; }}\n"
+declarations["member_getter"] = "\tconst {type}& {fname}() const;\n"
+implementations["member_getter"] = "\tconst {type}& {classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
 
-declarations["member_builtin_setter"] = "\tvoid {name}({type} value);\n\n"
-implementations["member_builtin_setter"] = "void {classname}::{name}({type} value){{ m_obj->data.{name} = value; }}\n"
+declarations["member_builtin_setter"] = "\tvoid {fname}({type} value);\n\n"
+implementations["member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{name} = value; }}\n"
 # conceptually getting a non-const ref is a setter:
 declarations["member_class_refsetter"] = "\t{type}& {name}();\n"
 implementations["member_class_refsetter"] = "\t{type}& {classname}::{name}() {{ return m_obj->data.{name}; }}\n"
-declarations["member_class_setter"] = "\tvoid {name}(class {type} value);\n"
-implementations["member_class_setter"] = "void {classname}::{name}(class {type} value) {{ m_obj->data.{name} = value; }}\n"
+declarations["member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
+implementations["member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{name} = value; }}\n"
 
 # this is inline, don't need the declaration
-implementations["const_member_getter"] = "\tconst {type}& Const{classname}::{name}() const {{ return m_obj->data.{name}; }}\n"
+implementations["const_member_getter"] = "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
 
 # OneToOneRelations
 #-----------------------------------

--- a/templates/ConstObject.h.template
+++ b/templates/ConstObject.h.template
@@ -61,6 +61,7 @@ $constextracode_declarations
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ${name}& p1,
 //       const ${name}& p2 );
+  bool operator<(const Const${name}& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/templates/Object.h.template
+++ b/templates/Object.h.template
@@ -64,6 +64,7 @@ $extracode_declarations
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ${name}& p1,
 //       const ${name}& p2 );
+  bool operator<(const ${name}& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/templates/RefVector.cc.template
+++ b/templates/RefVector.cc.template
@@ -10,7 +10,7 @@ std::vector<${relationtype}>::const_iterator ${classname}::${relation}_end() con
   return ++ret_value;
 }
 
-void ${classname}::add${relation}(${relationtype} component) {
+void ${classname}::${add_relation}(${relationtype} component) {
   m_obj->m_${relation}->push_back(component);
   m_obj->data.${relation}_end++;
 }
@@ -19,9 +19,13 @@ unsigned int ${classname}::${relation}_size() const {
   return (m_obj->data.${relation}_end-m_obj->data.${relation}_begin);
 }
 
-${relationtype} ${classname}::${relation}(unsigned int index) const {
+${relationtype} ${classname}::${get_relation}(unsigned int index) const {
   if (${relation}_size() > index) {
     return m_obj->m_${relation}->at(m_obj->data.${relation}_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
+}
+
+std::vector<${relationtype}>& ${classname}::${get_relation}() const {
+  return  *m_obj->m_${relation} ;
 }

--- a/templates/RefVector.cc.template
+++ b/templates/RefVector.cc.template
@@ -25,7 +25,3 @@ ${relationtype} ${classname}::${get_relation}(unsigned int index) const {
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-
-std::vector<${relationtype}>& ${classname}::${get_relation}() const {
-  return  *m_obj->m_${relation} ;
-}

--- a/templates/RefVector.h.template
+++ b/templates/RefVector.h.template
@@ -1,6 +1,5 @@
   void ${add_relation}(${relationtype});
   unsigned int ${relation}_size() const;
-  std::vector<${relationtype}>& ${get_relation}() const ;
   ${relationtype} ${get_relation}(unsigned int) const;
   std::vector<${relationtype}>::const_iterator ${relation}_begin() const;
   std::vector<${relationtype}>::const_iterator ${relation}_end() const;

--- a/templates/RefVector.h.template
+++ b/templates/RefVector.h.template
@@ -1,5 +1,7 @@
-  void add${relation}(${relationtype});
+  void ${add_relation}(${relationtype});
   unsigned int ${relation}_size() const;
-  ${relationtype} ${relation}(unsigned int) const;
+  std::vector<${relationtype}>& ${get_relation}() const ;
+  ${relationtype} ${get_relation}(unsigned int) const;
   std::vector<${relationtype}>::const_iterator ${relation}_begin() const;
   std::vector<${relationtype}>::const_iterator ${relation}_end() const;
+

--- a/tests/datamodel/EventInfo.h
+++ b/tests/datamodel/EventInfo.h
@@ -69,6 +69,7 @@ int getNumber() const;
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const EventInfo& p1,
 //       const EventInfo& p2 );
+  bool operator<(const EventInfo& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/EventInfoConst.h
+++ b/tests/datamodel/EventInfoConst.h
@@ -63,6 +63,7 @@ int getNumber() const;
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const EventInfo& p1,
 //       const EventInfo& p2 );
+  bool operator<(const ConstEventInfo& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -57,14 +57,12 @@ public:
 
   void addHits(ConstExampleHit);
   unsigned int Hits_size() const;
-  std::vector<ConstExampleHit>& Hits() const ;
   ConstExampleHit Hits(unsigned int) const;
   std::vector<ConstExampleHit>::const_iterator Hits_begin() const;
   std::vector<ConstExampleHit>::const_iterator Hits_end() const;
 
   void addClusters(ConstExampleCluster);
   unsigned int Clusters_size() const;
-  std::vector<ConstExampleCluster>& Clusters() const ;
   ConstExampleCluster Clusters(unsigned int) const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -57,14 +57,18 @@ public:
 
   void addHits(ConstExampleHit);
   unsigned int Hits_size() const;
+  std::vector<ConstExampleHit>& Hits() const ;
   ConstExampleHit Hits(unsigned int) const;
   std::vector<ConstExampleHit>::const_iterator Hits_begin() const;
   std::vector<ConstExampleHit>::const_iterator Hits_end() const;
+
   void addClusters(ConstExampleCluster);
   unsigned int Clusters_size() const;
+  std::vector<ConstExampleCluster>& Clusters() const ;
   ConstExampleCluster Clusters(unsigned int) const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+
 
 
   /// check whether the object is actually available
@@ -81,6 +85,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleCluster& p1,
 //       const ExampleCluster& p2 );
+  bool operator<(const ExampleCluster& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleClusterConst.h
+++ b/tests/datamodel/ExampleClusterConst.h
@@ -74,6 +74,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleCluster& p1,
 //       const ExampleCluster& p2 );
+  bool operator<(const ConstExampleCluster& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleForCyclicDependency1.h
+++ b/tests/datamodel/ExampleForCyclicDependency1.h
@@ -68,6 +68,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleForCyclicDependency1& p1,
 //       const ExampleForCyclicDependency1& p2 );
+  bool operator<(const ExampleForCyclicDependency1& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleForCyclicDependency1Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Const.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleForCyclicDependency1& p1,
 //       const ExampleForCyclicDependency1& p2 );
+  bool operator<(const ConstExampleForCyclicDependency1& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleForCyclicDependency2.h
+++ b/tests/datamodel/ExampleForCyclicDependency2.h
@@ -68,6 +68,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleForCyclicDependency2& p1,
 //       const ExampleForCyclicDependency2& p2 );
+  bool operator<(const ExampleForCyclicDependency2& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleForCyclicDependency2Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Const.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleForCyclicDependency2& p1,
 //       const ExampleForCyclicDependency2& p2 );
+  bool operator<(const ConstExampleForCyclicDependency2& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleHit.h
+++ b/tests/datamodel/ExampleHit.h
@@ -77,6 +77,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleHit& p1,
 //       const ExampleHit& p2 );
+  bool operator<(const ExampleHit& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleHitConst.h
+++ b/tests/datamodel/ExampleHitConst.h
@@ -66,6 +66,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleHit& p1,
 //       const ExampleHit& p2 );
+  bool operator<(const ConstExampleHit& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -53,14 +53,18 @@ public:
 
   void addClusters(ConstExampleCluster);
   unsigned int Clusters_size() const;
+  std::vector<ConstExampleCluster>& Clusters() const ;
   ConstExampleCluster Clusters(unsigned int) const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+
   void addRefs(ConstExampleReferencingType);
   unsigned int Refs_size() const;
+  std::vector<ConstExampleReferencingType>& Refs() const ;
   ConstExampleReferencingType Refs(unsigned int) const;
   std::vector<ConstExampleReferencingType>::const_iterator Refs_begin() const;
   std::vector<ConstExampleReferencingType>::const_iterator Refs_end() const;
+
 
 
   /// check whether the object is actually available
@@ -77,6 +81,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleReferencingType& p1,
 //       const ExampleReferencingType& p2 );
+  bool operator<(const ExampleReferencingType& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -53,14 +53,12 @@ public:
 
   void addClusters(ConstExampleCluster);
   unsigned int Clusters_size() const;
-  std::vector<ConstExampleCluster>& Clusters() const ;
   ConstExampleCluster Clusters(unsigned int) const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
 
   void addRefs(ConstExampleReferencingType);
   unsigned int Refs_size() const;
-  std::vector<ConstExampleReferencingType>& Refs() const ;
   ConstExampleReferencingType Refs(unsigned int) const;
   std::vector<ConstExampleReferencingType>::const_iterator Refs_begin() const;
   std::vector<ConstExampleReferencingType>::const_iterator Refs_end() const;

--- a/tests/datamodel/ExampleReferencingTypeConst.h
+++ b/tests/datamodel/ExampleReferencingTypeConst.h
@@ -72,6 +72,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleReferencingType& p1,
 //       const ExampleReferencingType& p2 );
+  bool operator<(const ConstExampleReferencingType& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -70,6 +70,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithARelation& p1,
 //       const ExampleWithARelation& p2 );
+  bool operator<(const ExampleWithARelation& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -66,6 +66,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithARelation& p1,
 //       const ExampleWithARelation& p2 );
+  bool operator<(const ConstExampleWithARelation& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithComponent.h
+++ b/tests/datamodel/ExampleWithComponent.h
@@ -69,6 +69,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithComponent& p1,
 //       const ExampleWithComponent& p2 );
+  bool operator<(const ExampleWithComponent& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithComponentConst.h
+++ b/tests/datamodel/ExampleWithComponentConst.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithComponent& p1,
 //       const ExampleWithComponent& p2 );
+  bool operator<(const ConstExampleWithComponent& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithNamespace.h
+++ b/tests/datamodel/ExampleWithNamespace.h
@@ -69,6 +69,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithNamespace& p1,
 //       const ExampleWithNamespace& p2 );
+  bool operator<(const ExampleWithNamespace& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithNamespaceConst.h
+++ b/tests/datamodel/ExampleWithNamespaceConst.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithNamespace& p1,
 //       const ExampleWithNamespace& p2 );
+  bool operator<(const ConstExampleWithNamespace& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithOneRelation.h
+++ b/tests/datamodel/ExampleWithOneRelation.h
@@ -68,6 +68,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithOneRelation& p1,
 //       const ExampleWithOneRelation& p2 );
+  bool operator<(const ExampleWithOneRelation& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithOneRelationConst.h
+++ b/tests/datamodel/ExampleWithOneRelationConst.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithOneRelation& p1,
 //       const ExampleWithOneRelation& p2 );
+  bool operator<(const ConstExampleWithOneRelation& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithString.h
+++ b/tests/datamodel/ExampleWithString.h
@@ -69,6 +69,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithString& p1,
 //       const ExampleWithString& p2 );
+  bool operator<(const ExampleWithString& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithStringConst.h
+++ b/tests/datamodel/ExampleWithStringConst.h
@@ -64,6 +64,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithString& p1,
 //       const ExampleWithString& p2 );
+  bool operator<(const ConstExampleWithString& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithVectorMember.h
+++ b/tests/datamodel/ExampleWithVectorMember.h
@@ -51,7 +51,6 @@ public:
 
   void addcount(int);
   unsigned int count_size() const;
-  std::vector<int>& count() const ;
   int count(unsigned int) const;
   std::vector<int>::const_iterator count_begin() const;
   std::vector<int>::const_iterator count_end() const;

--- a/tests/datamodel/ExampleWithVectorMember.h
+++ b/tests/datamodel/ExampleWithVectorMember.h
@@ -51,9 +51,11 @@ public:
 
   void addcount(int);
   unsigned int count_size() const;
+  std::vector<int>& count() const ;
   int count(unsigned int) const;
   std::vector<int>::const_iterator count_begin() const;
   std::vector<int>::const_iterator count_end() const;
+
 
 
   /// check whether the object is actually available
@@ -70,6 +72,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithVectorMember& p1,
 //       const ExampleWithVectorMember& p2 );
+  bool operator<(const ExampleWithVectorMember& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/datamodel/ExampleWithVectorMemberConst.h
+++ b/tests/datamodel/ExampleWithVectorMemberConst.h
@@ -66,6 +66,7 @@ public:
 // less comparison operator, so that objects can be e.g. stored in sets.
 //  friend bool operator< (const ExampleWithVectorMember& p1,
 //       const ExampleWithVectorMember& p2 );
+  bool operator<(const ConstExampleWithVectorMember& other) const { return m_obj < other.m_obj  ; }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/src/ExampleCluster.cc
+++ b/tests/src/ExampleCluster.cc
@@ -75,10 +75,6 @@ ConstExampleHit ExampleCluster::Hits(unsigned int index) const {
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-
-std::vector<ConstExampleHit>& ExampleCluster::Hits() const {
-  return  *m_obj->m_Hits ;
-}
 std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
@@ -105,10 +101,6 @@ ConstExampleCluster ExampleCluster::Clusters(unsigned int index) const {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
-}
-
-std::vector<ConstExampleCluster>& ExampleCluster::Clusters() const {
-  return  *m_obj->m_Clusters ;
 }
 
 

--- a/tests/src/ExampleCluster.cc
+++ b/tests/src/ExampleCluster.cc
@@ -75,6 +75,10 @@ ConstExampleHit ExampleCluster::Hits(unsigned int index) const {
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
+
+std::vector<ConstExampleHit>& ExampleCluster::Hits() const {
+  return  *m_obj->m_Hits ;
+}
 std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
@@ -101,6 +105,10 @@ ConstExampleCluster ExampleCluster::Clusters(unsigned int index) const {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
+}
+
+std::vector<ConstExampleCluster>& ExampleCluster::Clusters() const {
+  return  *m_obj->m_Clusters ;
 }
 
 

--- a/tests/src/ExampleReferencingType.cc
+++ b/tests/src/ExampleReferencingType.cc
@@ -69,10 +69,6 @@ ConstExampleCluster ExampleReferencingType::Clusters(unsigned int index) const {
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-
-std::vector<ConstExampleCluster>& ExampleReferencingType::Clusters() const {
-  return  *m_obj->m_Clusters ;
-}
 std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
@@ -99,10 +95,6 @@ ConstExampleReferencingType ExampleReferencingType::Refs(unsigned int index) con
     return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
-}
-
-std::vector<ConstExampleReferencingType>& ExampleReferencingType::Refs() const {
-  return  *m_obj->m_Refs ;
 }
 
 

--- a/tests/src/ExampleReferencingType.cc
+++ b/tests/src/ExampleReferencingType.cc
@@ -69,6 +69,10 @@ ConstExampleCluster ExampleReferencingType::Clusters(unsigned int index) const {
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
+
+std::vector<ConstExampleCluster>& ExampleReferencingType::Clusters() const {
+  return  *m_obj->m_Clusters ;
+}
 std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
@@ -95,6 +99,10 @@ ConstExampleReferencingType ExampleReferencingType::Refs(unsigned int index) con
     return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
+}
+
+std::vector<ConstExampleReferencingType>& ExampleReferencingType::Refs() const {
+  return  *m_obj->m_Refs ;
 }
 
 

--- a/tests/src/ExampleWithVectorMember.cc
+++ b/tests/src/ExampleWithVectorMember.cc
@@ -70,6 +70,10 @@ int ExampleWithVectorMember::count(unsigned int index) const {
   else throw std::out_of_range ("index out of bounds for existing references");
 }
 
+std::vector<int>& ExampleWithVectorMember::count() const {
+  return  *m_obj->m_count ;
+}
+
 
 bool  ExampleWithVectorMember::isAvailable() const {
   if (m_obj != nullptr) {

--- a/tests/src/ExampleWithVectorMember.cc
+++ b/tests/src/ExampleWithVectorMember.cc
@@ -70,10 +70,6 @@ int ExampleWithVectorMember::count(unsigned int index) const {
   else throw std::out_of_range ("index out of bounds for existing references");
 }
 
-std::vector<int>& ExampleWithVectorMember::count() const {
-  return  *m_obj->m_count ;
-}
-
 
 bool  ExampleWithVectorMember::isAvailable() const {
   if (m_obj != nullptr) {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -222,6 +222,43 @@ TEST_CASE("Extracode") {
 
 }
 
+
+TEST_CASE("AssociativeContainer") {
+  auto clu1 = ExampleCluster();
+  auto clu2 = ExampleCluster();
+  auto clu3 = ExampleCluster();
+  auto clu4 = ExampleCluster();
+  auto clu5 = ExampleCluster();
+
+  std::set<ExampleCluster> cSet ;
+  cSet.insert( clu1 ) ;
+  cSet.insert( clu2 ) ;
+  cSet.insert( clu3 ) ;
+  cSet.insert( clu4 ) ;
+  cSet.insert( clu5 ) ;
+  cSet.insert( clu1 ) ;
+  cSet.insert( clu2 ) ;
+  cSet.insert( clu3 ) ;
+  cSet.insert( clu4 ) ;
+  cSet.insert( clu5 ) ;
+
+  REQUIRE( cSet.size() == 5 );
+
+  std::map<ExampleCluster,int> cMap ;
+  cMap[ clu1 ] = 1  ;
+  cMap[ clu2 ] = 2  ;
+  cMap[ clu3 ] = 3  ;
+  cMap[ clu4 ] = 4  ;
+  cMap[ clu5 ] = 5  ;
+
+  REQUIRE( cMap[ clu3 ]  == 3 );
+  
+  cMap[ clu3 ] = 42  ;
+
+  REQUIRE( cMap[ clu3 ]  == 42 );
+
+}
+
 TEST_CASE("Equality") {
   auto cluster = ExampleCluster();
   auto rel = ExampleWithOneRelation();


### PR DESCRIPTION
 - add option -g [--getSyntax] for createing getters and setters
   as getMember()/setMember()

 - add operator<() for Objects and ConstObjects so that they can be stored in maps

 - add getter for reference vector (additional to begin/end iterators)

 - updated (re-generated) example data model accordingly
   ( no change in any other code)