### PR TITLE
Relation bug

### DIFF
--- a/templates/RefVector.cc.template
+++ b/templates/RefVector.cc.template
@@ -6,8 +6,11 @@ std::vector<${relationtype}>::const_iterator ${classname}::${relation}_begin() c
 
 std::vector<${relationtype}>::const_iterator ${classname}::${relation}_end() const {
   auto ret_value = m_obj->m_${relation}->begin();
-  std::advance(ret_value, m_obj->data.${relation}_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.${relation}==0
+//  std::advance(ret_value, m_obj->data.${relation}_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.${relation}_end);
+  return ret_value;
 }
 
 void ${classname}::${add_relation}(${relationtype} component) {

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -43,6 +43,16 @@ datatypes :
      - double z      // z-coordinate
      - double energy // measured energy deposit
 
+  ExampleMC :
+    Description : "Example MC-particle"
+    Author: "F.Gaede"
+    Members:
+      - double energy  // energy
+      - int PDG  // PDG code
+    OneToManyRelations:
+      - ExampleMC parents   // parents
+      - ExampleMC daughters  // daughters
+
   ExampleCluster :
     Description : "Cluster"
     Author : "B. Hegner"

--- a/tests/datamodel/ExampleMC.h
+++ b/tests/datamodel/ExampleMC.h
@@ -1,0 +1,100 @@
+#ifndef ExampleMC_H
+#define ExampleMC_H
+#include "ExampleMCData.h"
+#include <vector>
+#include "ExampleMC.h"
+#include "ExampleMC.h"
+#include <vector>
+#include "podio/ObjectID.h"
+
+// Example MC-particle
+// author: F.Gaede
+
+//forward declarations
+
+
+#include "ExampleMCConst.h"
+#include "ExampleMCObj.h"
+
+
+
+class ExampleMCCollection;
+class ExampleMCCollectionIterator;
+class ConstExampleMC;
+
+class ExampleMC {
+
+  friend ExampleMCCollection;
+  friend ExampleMCCollectionIterator;
+  friend ConstExampleMC;
+
+public:
+
+  /// default constructor
+  ExampleMC();
+  ExampleMC(double energy,int PDG);
+
+  /// constructor from existing ExampleMCObj
+  ExampleMC(ExampleMCObj* obj);
+  /// copy constructor
+  ExampleMC(const ExampleMC& other);
+  /// copy-assignment operator
+  ExampleMC& operator=(const ExampleMC& other);
+  /// support cloning (deep-copy)
+  ExampleMC clone() const;
+  /// destructor
+  ~ExampleMC();
+
+  /// conversion to const object
+  operator ConstExampleMC () const;
+
+public:
+
+  const double& energy() const;
+  const int& PDG() const;
+
+  void energy(double value);
+
+  void PDG(int value);
+
+
+  void addparents(ConstExampleMC);
+  unsigned int parents_size() const;
+  ConstExampleMC parents(unsigned int) const;
+  std::vector<ConstExampleMC>::const_iterator parents_begin() const;
+  std::vector<ConstExampleMC>::const_iterator parents_end() const;
+
+  void adddaughters(ConstExampleMC);
+  unsigned int daughters_size() const;
+  ConstExampleMC daughters(unsigned int) const;
+  std::vector<ConstExampleMC>::const_iterator daughters_begin() const;
+  std::vector<ConstExampleMC>::const_iterator daughters_end() const;
+
+
+
+  /// check whether the object is actually available
+  bool isAvailable() const;
+  /// disconnect from ExampleMCObj instance
+  void unlink(){m_obj = nullptr;}
+
+  bool operator==(const ExampleMC& other) const {
+    return (m_obj==other.m_obj);
+  }
+
+  bool operator==(const ConstExampleMC& other) const;
+
+// less comparison operator, so that objects can be e.g. stored in sets.
+//  friend bool operator< (const ExampleMC& p1,
+//       const ExampleMC& p2 );
+  bool operator<(const ExampleMC& other) const { return m_obj < other.m_obj  ; }
+
+  const podio::ObjectID getObjectID() const;
+
+private:
+  ExampleMCObj* m_obj;
+
+};
+
+
+
+#endif

--- a/tests/datamodel/ExampleMCCollection.h
+++ b/tests/datamodel/ExampleMCCollection.h
@@ -1,0 +1,159 @@
+//AUTOMATICALLY GENERATED - DO NOT EDIT
+
+#ifndef ExampleMCCollection_H
+#define  ExampleMCCollection_H
+
+#include <string>
+#include <vector>
+#include <deque>
+#include <array>
+#include <algorithm>
+
+// podio specific includes
+#include "podio/ICollectionProvider.h"
+#include "podio/CollectionBase.h"
+#include "podio/CollectionIDTable.h"
+
+// datamodel specific includes
+#include "ExampleMCData.h"
+#include "ExampleMC.h"
+#include "ExampleMCObj.h"
+
+
+typedef std::vector<ExampleMCData> ExampleMCDataContainer;
+typedef std::deque<ExampleMCObj*> ExampleMCObjPointerContainer;
+
+class ExampleMCCollectionIterator {
+
+  public:
+    ExampleMCCollectionIterator(int index, const ExampleMCObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+
+    bool operator!=(const ExampleMCCollectionIterator& x) const {
+      return m_index != x.m_index; //TODO: may not be complete
+    }
+
+    const ExampleMC operator*() const;
+    const ExampleMC* operator->() const;
+    const ExampleMCCollectionIterator& operator++() const;
+
+  private:
+    mutable int m_index;
+    mutable ExampleMC m_object;
+    const ExampleMCObjPointerContainer* m_collection;
+};
+
+/**
+A Collection is identified by an ID.
+*/
+
+class ExampleMCCollection : public podio::CollectionBase {
+
+public:
+  typedef const ExampleMCCollectionIterator const_iterator;
+
+  ExampleMCCollection();
+//  ExampleMCCollection(const ExampleMCCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
+//  ExampleMCCollection(ExampleMCVector* data, int collectionID);
+  ~ExampleMCCollection();
+
+  void clear();
+  /// Append a new object to the collection, and return this object.
+  ExampleMC create();
+
+  /// Append a new object to the collection, and return this object.
+  /// Initialized with the parameters given
+  template<typename... Args>
+  ExampleMC create(Args&&... args);
+  int size() const;
+
+  /// Returns the object of given index
+  const ExampleMC operator[](unsigned int index) const;
+  /// Returns the object of given index
+  const ExampleMC at(unsigned int index) const;
+
+
+  /// Append object to the collection
+  void push_back(ConstExampleMC object);
+
+  void prepareForWrite();
+  void prepareAfterRead();
+  void setBuffer(void* address);
+  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+
+  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+
+  void setID(unsigned ID){
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(),m_entries.end(),
+                 [ID](ExampleMCObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
+    );
+  };
+
+  bool isValid() const {
+    return m_isValid;
+  }
+
+  // support for the iterator protocol
+  const const_iterator begin() const {
+    return const_iterator(0, &m_entries);
+  }
+  const const_iterator end() const {
+    return const_iterator(m_entries.size(), &m_entries);
+  }
+
+  /// returns the address of the pointer to the data buffer
+  void* getBufferAddress() { return (void*)&m_data;};
+
+  /// returns the pointer to the data buffer
+  std::vector<ExampleMCData>* _getBuffer() { return m_data;};
+
+    template<size_t arraysize>
+  const std::array<double,arraysize> energy() const;
+  template<size_t arraysize>
+  const std::array<int,arraysize> PDG() const;
+
+
+private:
+  bool m_isValid;
+  int m_collectionID;
+  ExampleMCObjPointerContainer m_entries;
+  // members to handle 1-to-N-relations
+  std::vector<::ConstExampleMC>* m_rel_parents; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleMC>*> m_rel_parents_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleMC>* m_rel_daughters; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleMC>*> m_rel_daughters_tmp; ///< Relation buffer for internal book-keeping
+
+  // members to handle streaming
+  podio::CollRefCollection m_refCollections;
+  ExampleMCDataContainer* m_data;
+};
+
+template<typename... Args>
+ExampleMC  ExampleMCCollection::create(Args&&... args){
+  int size = m_entries.size();
+  auto obj = new ExampleMCObj({size,m_collectionID},{args...});
+  m_entries.push_back(obj);
+  return ExampleMC(obj);
+}
+
+template<size_t arraysize>
+const std::array<double,arraysize> ExampleMCCollection::energy() const {
+  std::array<double,arraysize> tmp;
+  auto valid_size = std::min(arraysize,m_entries.size());
+  for (unsigned i = 0; i<valid_size; ++i){
+    tmp[i] = m_entries[i]->data.energy;
+ }
+ return tmp;
+}
+template<size_t arraysize>
+const std::array<int,arraysize> ExampleMCCollection::PDG() const {
+  std::array<int,arraysize> tmp;
+  auto valid_size = std::min(arraysize,m_entries.size());
+  for (unsigned i = 0; i<valid_size; ++i){
+    tmp[i] = m_entries[i]->data.PDG;
+ }
+ return tmp;
+}
+
+
+#endif

--- a/tests/datamodel/ExampleMCConst.h
+++ b/tests/datamodel/ExampleMCConst.h
@@ -1,0 +1,88 @@
+#ifndef ConstExampleMC_H
+#define ConstExampleMC_H
+#include "ExampleMCData.h"
+#include <vector>
+#include "ExampleMC.h"
+#include "ExampleMC.h"
+#include <vector>
+#include "podio/ObjectID.h"
+
+// Example MC-particle
+// author: F.Gaede
+
+//forward declarations
+
+
+#include "ExampleMCObj.h"
+
+
+
+class ExampleMCObj;
+class ExampleMC;
+class ExampleMCCollection;
+class ExampleMCCollectionIterator;
+
+class ConstExampleMC {
+
+  friend ExampleMC;
+  friend ExampleMCCollection;
+  friend ExampleMCCollectionIterator;
+
+public:
+
+  /// default constructor
+  ConstExampleMC();
+  ConstExampleMC(double energy,int PDG);
+
+  /// constructor from existing ExampleMCObj
+  ConstExampleMC(ExampleMCObj* obj);
+  /// copy constructor
+  ConstExampleMC(const ConstExampleMC& other);
+  /// copy-assignment operator
+  ConstExampleMC& operator=(const ConstExampleMC& other);
+  /// support cloning (deep-copy)
+  ConstExampleMC clone() const;
+  /// destructor
+  ~ConstExampleMC();
+
+
+public:
+
+  const double& energy() const;
+  const int& PDG() const;
+
+  unsigned int parents_size() const;
+  ConstExampleMC parents(unsigned int) const;
+  std::vector<ConstExampleMC>::const_iterator parents_begin() const;
+  std::vector<ConstExampleMC>::const_iterator parents_end() const;
+  unsigned int daughters_size() const;
+  ConstExampleMC daughters(unsigned int) const;
+  std::vector<ConstExampleMC>::const_iterator daughters_begin() const;
+  std::vector<ConstExampleMC>::const_iterator daughters_end() const;
+
+
+  /// check whether the object is actually available
+  bool isAvailable() const;
+  /// disconnect from ExampleMCObj instance
+  void unlink(){m_obj = nullptr;}
+
+  bool operator==(const ConstExampleMC& other) const {
+       return (m_obj==other.m_obj);
+  }
+
+  bool operator==(const ExampleMC& other) const;
+
+// less comparison operator, so that objects can be e.g. stored in sets.
+//  friend bool operator< (const ExampleMC& p1,
+//       const ExampleMC& p2 );
+  bool operator<(const ConstExampleMC& other) const { return m_obj < other.m_obj  ; }
+
+  const podio::ObjectID getObjectID() const;
+
+private:
+  ExampleMCObj* m_obj;
+
+};
+
+
+#endif

--- a/tests/datamodel/ExampleMCData.h
+++ b/tests/datamodel/ExampleMCData.h
@@ -1,0 +1,21 @@
+#ifndef ExampleMCDATA_H
+#define ExampleMCDATA_H
+
+// Example MC-particle
+// author: F.Gaede
+
+
+
+
+class ExampleMCData {
+public:
+  double energy;  ///< energy
+  int PDG;  ///< PDG code
+  unsigned int parents_begin;
+  unsigned int parents_end;
+  unsigned int daughters_begin;
+  unsigned int daughters_end;
+};
+
+
+#endif

--- a/tests/datamodel/ExampleMCObj.h
+++ b/tests/datamodel/ExampleMCObj.h
@@ -1,0 +1,42 @@
+#ifndef ExampleMCOBJ_H
+#define ExampleMCOBJ_H
+
+// std includes
+#include <atomic>
+#include <iostream>
+
+// data model specific includes
+#include "podio/ObjBase.h"
+#include "ExampleMCData.h"
+
+#include <vector>
+
+
+// forward declarations
+class ExampleMC;
+class ConstExampleMC;
+
+
+
+class ExampleMCObj : public podio::ObjBase {
+public:
+  /// constructor
+  ExampleMCObj();
+  /// copy constructor (does a deep-copy of relation containers)
+  ExampleMCObj(const ExampleMCObj&);
+  /// constructor from ObjectID and ExampleMCData
+  /// does not initialize the internal relation containers
+  ExampleMCObj(const podio::ObjectID id, ExampleMCData data);
+  virtual ~ExampleMCObj();
+
+public:
+  ExampleMCData data;
+  std::vector<ConstExampleMC>* m_parents;
+  std::vector<ConstExampleMC>* m_daughters;
+
+
+};
+
+
+
+#endif

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -10,6 +10,7 @@
 // test data model
 #include "ExampleHitCollection.h"
 #include "ExampleClusterCollection.h"
+#include "ExampleMCCollection.h"
 #include "ExampleReferencingTypeCollection.h"
 #include "ExampleWithOneRelationCollection.h"
 #include "ExampleWithVectorMemberCollection.h"
@@ -25,7 +26,7 @@ void processEvent(podio::EventStore& store, bool verboser) {
   auto& failing = store.get<ExampleClusterCollection>("notthere");
   if(failing.isValid() == true) {
     throw std::runtime_error("Collection 'notthere' should not be valid");
-};
+  };
 
   auto& strings = store.get<ExampleWithStringCollection>("strings");
   if(strings.isValid()){
@@ -44,6 +45,25 @@ void processEvent(podio::EventStore& store, bool verboser) {
       glob++;
     }
   }
+
+
+  auto& mcps =  store.get<ExampleMCCollection>("mcparticles");
+  if( mcps.isValid() ){
+
+    for( auto p : mcps ){
+      std::cout << " particle " << p.getObjectID().index << " daughters: " ;
+      for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
+	int dIndex = it->getObjectID().index ;
+	std::cout << " " << dIndex ;
+      } 
+      std::cout << "  and parents: " ;
+      for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
+	std::cout << " " << it->getObjectID().index ;
+      }
+      std::cout << std::endl ;
+    }
+  }
+
 
   //std::cout << "Fetching collection 'refs'" << std::endl;
   auto& refs = store.get<ExampleReferencingTypeCollection>("refs");

--- a/tests/src/ExampleCluster.cc
+++ b/tests/src/ExampleCluster.cc
@@ -56,8 +56,11 @@ std::vector<ConstExampleHit>::const_iterator ExampleCluster::Hits_begin() const 
 
 std::vector<ConstExampleHit>::const_iterator ExampleCluster::Hits_end() const {
   auto ret_value = m_obj->m_Hits->begin();
-  std::advance(ret_value, m_obj->data.Hits_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.Hits==0
+//  std::advance(ret_value, m_obj->data.Hits_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.Hits_end);
+  return ret_value;
 }
 
 void ExampleCluster::addHits(ConstExampleHit component) {
@@ -83,8 +86,11 @@ std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin(
 
 std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
-  std::advance(ret_value, m_obj->data.Clusters_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.Clusters==0
+//  std::advance(ret_value, m_obj->data.Clusters_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.Clusters_end);
+  return ret_value;
 }
 
 void ExampleCluster::addClusters(ConstExampleCluster component) {

--- a/tests/src/ExampleMC.cc
+++ b/tests/src/ExampleMC.cc
@@ -1,0 +1,142 @@
+// datamodel specific includes
+#include "ExampleMC.h"
+#include "ExampleMCConst.h"
+#include "ExampleMCObj.h"
+#include "ExampleMCData.h"
+#include "ExampleMCCollection.h"
+#include <iostream>
+
+
+
+
+ExampleMC::ExampleMC() : m_obj(new ExampleMCObj()){
+ m_obj->acquire();
+}
+
+ExampleMC::ExampleMC(double energy,int PDG) : m_obj(new ExampleMCObj()) {
+  m_obj->acquire();
+    m_obj->data.energy = energy;  m_obj->data.PDG = PDG;
+}
+
+
+ExampleMC::ExampleMC(const ExampleMC& other) : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleMC& ExampleMC::operator=(const ExampleMC& other) {
+  if ( m_obj != nullptr) m_obj->release();
+  m_obj = other.m_obj;
+  return *this;
+}
+
+ExampleMC::ExampleMC(ExampleMCObj* obj) : m_obj(obj){
+  if(m_obj != nullptr)
+    m_obj->acquire();
+}
+
+ExampleMC ExampleMC::clone() const {
+  return {new ExampleMCObj(*m_obj)};
+}
+
+ExampleMC::~ExampleMC(){
+  if ( m_obj != nullptr) m_obj->release();
+}
+
+ExampleMC::operator ConstExampleMC() const {return ConstExampleMC(m_obj);}
+
+  const double& ExampleMC::energy() const { return m_obj->data.energy; }
+  const int& ExampleMC::PDG() const { return m_obj->data.PDG; }
+
+void ExampleMC::energy(double value){ m_obj->data.energy = value; }
+void ExampleMC::PDG(int value){ m_obj->data.PDG = value; }
+
+std::vector<ConstExampleMC>::const_iterator ExampleMC::parents_begin() const {
+  auto ret_value = m_obj->m_parents->begin();
+  std::advance(ret_value, m_obj->data.parents_begin);
+  return ret_value;
+}
+
+std::vector<ConstExampleMC>::const_iterator ExampleMC::parents_end() const {
+  auto ret_value = m_obj->m_parents->begin();
+//fg: this code fails if m_obj->data.parents==0
+//  std::advance(ret_value, m_obj->data.parents_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.parents_end);
+  return ret_value;
+}
+
+void ExampleMC::addparents(ConstExampleMC component) {
+  m_obj->m_parents->push_back(component);
+  m_obj->data.parents_end++;
+}
+
+unsigned int ExampleMC::parents_size() const {
+  return (m_obj->data.parents_end-m_obj->data.parents_begin);
+}
+
+ConstExampleMC ExampleMC::parents(unsigned int index) const {
+  if (parents_size() > index) {
+    return m_obj->m_parents->at(m_obj->data.parents_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
+std::vector<ConstExampleMC>::const_iterator ExampleMC::daughters_begin() const {
+  auto ret_value = m_obj->m_daughters->begin();
+  std::advance(ret_value, m_obj->data.daughters_begin);
+  return ret_value;
+}
+
+std::vector<ConstExampleMC>::const_iterator ExampleMC::daughters_end() const {
+  auto ret_value = m_obj->m_daughters->begin();
+//fg: this code fails if m_obj->data.daughters==0
+//  std::advance(ret_value, m_obj->data.daughters_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.daughters_end);
+  return ret_value;
+}
+
+void ExampleMC::adddaughters(ConstExampleMC component) {
+  m_obj->m_daughters->push_back(component);
+  m_obj->data.daughters_end++;
+}
+
+unsigned int ExampleMC::daughters_size() const {
+  return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
+}
+
+ConstExampleMC ExampleMC::daughters(unsigned int index) const {
+  if (daughters_size() > index) {
+    return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
+
+
+bool  ExampleMC::isAvailable() const {
+  if (m_obj != nullptr) {
+    return true;
+  }
+  return false;
+}
+
+const podio::ObjectID ExampleMC::getObjectID() const {
+  if (m_obj !=nullptr){
+    return m_obj->id;
+  }
+  return podio::ObjectID{-2,-2};
+}
+
+bool ExampleMC::operator==(const ConstExampleMC& other) const {
+  return (m_obj==other.m_obj);
+}
+
+
+//bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
+//  if( p1.m_containerID == p2.m_containerID ) {
+//    return p1.m_index < p2.m_index;
+//  } else {
+//    return p1.m_containerID < p2.m_containerID;
+//  }
+//}
+
+

--- a/tests/src/ExampleMCCollection.cc
+++ b/tests/src/ExampleMCCollection.cc
@@ -1,0 +1,176 @@
+// standard includes
+#include <stdexcept>
+#include "ExampleMCCollection.h" 
+#include "ExampleMCCollection.h" 
+
+
+#include "ExampleMCCollection.h"
+
+
+
+ExampleMCCollection::ExampleMCCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_parents(new std::vector<::ConstExampleMC>()), m_rel_daughters(new std::vector<::ConstExampleMC>()),m_data(new ExampleMCDataContainer() ) {
+    m_refCollections.push_back(new std::vector<podio::ObjectID>());
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
+
+}
+
+ExampleMCCollection::~ExampleMCCollection() {
+  clear();
+  if (m_data != nullptr) delete m_data;
+    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
+  if (m_rel_parents != nullptr) { delete m_rel_parents; }
+  if (m_rel_daughters != nullptr) { delete m_rel_daughters; }
+
+};
+
+const ExampleMC ExampleMCCollection::operator[](unsigned int index) const {
+  return ExampleMC(m_entries[index]);
+}
+
+const ExampleMC ExampleMCCollection::at(unsigned int index) const {
+  return ExampleMC(m_entries.at(index));
+}
+
+int  ExampleMCCollection::size() const {
+  return m_entries.size();
+}
+
+ExampleMC ExampleMCCollection::create(){
+  auto obj = new ExampleMCObj();
+  m_entries.emplace_back(obj);
+  m_rel_parents_tmp.push_back(obj->m_parents);
+  m_rel_daughters_tmp.push_back(obj->m_daughters);
+
+  obj->id = {int(m_entries.size()-1),m_collectionID};
+  return ExampleMC(obj);
+}
+
+void ExampleMCCollection::clear(){
+  m_data->clear();
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+  // clear relations to parents. Make sure to unlink() the reference data s they may be gone already.
+  for (auto& pointer : m_rel_parents_tmp) {
+    for(auto& item : (*pointer)) {
+      item.unlink();
+    };
+    delete pointer;
+  }
+  m_rel_parents_tmp.clear();
+  for (auto& item : (*m_rel_parents)) { item.unlink(); }
+  m_rel_parents->clear();
+  // clear relations to daughters. Make sure to unlink() the reference data s they may be gone already.
+  for (auto& pointer : m_rel_daughters_tmp) {
+    for(auto& item : (*pointer)) {
+      item.unlink();
+    };
+    delete pointer;
+  }
+  m_rel_daughters_tmp.clear();
+  for (auto& item : (*m_rel_daughters)) { item.unlink(); }
+  m_rel_daughters->clear();
+
+  for (auto& obj : m_entries) { delete obj; }
+  m_entries.clear();
+}
+
+void ExampleMCCollection::prepareForWrite(){
+  auto size = m_entries.size();
+  m_data->reserve(size);
+  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
+  for (auto& pointer : m_refCollections) {pointer->clear(); } 
+  int parents_index =0;
+  int daughters_index =0;
+
+  for(int i=0, size = m_data->size(); i != size; ++i){
+   (*m_data)[i].parents_begin=parents_index;
+   (*m_data)[i].parents_end+=parents_index;
+   parents_index = (*m_data)[parents_index].parents_end;
+   for(auto it : (*m_rel_parents_tmp[i])) {
+     if (it.getObjectID().index == podio::ObjectID::untracked)
+       throw std::runtime_error("Trying to persistify untracked object");
+     m_refCollections[0]->emplace_back(it.getObjectID());
+     m_rel_parents->push_back(it);
+   }
+   (*m_data)[i].daughters_begin=daughters_index;
+   (*m_data)[i].daughters_end+=daughters_index;
+   daughters_index = (*m_data)[daughters_index].daughters_end;
+   for(auto it : (*m_rel_daughters_tmp[i])) {
+     if (it.getObjectID().index == podio::ObjectID::untracked)
+       throw std::runtime_error("Trying to persistify untracked object");
+     m_refCollections[1]->emplace_back(it.getObjectID());
+     m_rel_daughters->push_back(it);
+   }
+
+  }
+
+}
+
+void ExampleMCCollection::prepareAfterRead(){
+  int index = 0;
+  for (auto& data : *m_data){
+    auto obj = new ExampleMCObj({index,m_collectionID}, data);
+        obj->m_parents = m_rel_parents;   obj->m_daughters = m_rel_daughters;
+    m_entries.emplace_back(obj);
+    ++index;
+  }
+  m_isValid = true;  
+}
+
+bool ExampleMCCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+    auto id = (*m_refCollections[0])[i];
+    CollectionBase* coll = nullptr;
+    collectionProvider->get(id.collectionID,coll);
+    ExampleMCCollection* tmp_coll = static_cast<ExampleMCCollection*>(coll);
+    auto tmp = (*tmp_coll)[id.index];
+    m_rel_parents->emplace_back(tmp);
+  }
+  for(unsigned int i=0, size=m_refCollections[1]->size();i!=size;++i) {
+    auto id = (*m_refCollections[1])[i];
+    CollectionBase* coll = nullptr;
+    collectionProvider->get(id.collectionID,coll);
+    ExampleMCCollection* tmp_coll = static_cast<ExampleMCCollection*>(coll);
+    auto tmp = (*tmp_coll)[id.index];
+    m_rel_daughters->emplace_back(tmp);
+  }
+
+
+  return true; //TODO: check success
+}
+
+void ExampleMCCollection::push_back(ConstExampleMC object){
+  int size = m_entries.size();
+  auto obj = object.m_obj;
+  if (obj->id.index == podio::ObjectID::untracked) {
+      obj->id = {size,m_collectionID};
+      m_entries.push_back(obj);
+        m_rel_parents_tmp.push_back(obj->m_parents);
+  m_rel_daughters_tmp.push_back(obj->m_daughters);
+
+  } else {
+    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+  }
+}
+
+void ExampleMCCollection::setBuffer(void* address){
+  if (m_data != nullptr) delete m_data;
+  m_data = static_cast<ExampleMCDataContainer*>(address);
+}
+
+
+const ExampleMC ExampleMCCollectionIterator::operator* () const {
+  m_object.m_obj = (*m_collection)[m_index];
+  return m_object;
+}
+
+const ExampleMC* ExampleMCCollectionIterator::operator-> () const {
+  m_object.m_obj = (*m_collection)[m_index];
+  return &m_object;
+}
+
+const ExampleMCCollectionIterator& ExampleMCCollectionIterator::operator++() const {
+  ++m_index;
+  return *this;
+}
+
+

--- a/tests/src/ExampleMCConst.cc
+++ b/tests/src/ExampleMCConst.cc
@@ -1,0 +1,120 @@
+// datamodel specific includes
+#include "ExampleMC.h"
+#include "ExampleMCConst.h"
+#include "ExampleMCObj.h"
+#include "ExampleMCData.h"
+#include "ExampleMCCollection.h"
+#include <iostream>
+
+
+
+
+ConstExampleMC::ConstExampleMC() : m_obj(new ExampleMCObj()) {
+ m_obj->acquire();
+}
+
+ConstExampleMC::ConstExampleMC(double energy,int PDG) : m_obj(new ExampleMCObj()){
+ m_obj->acquire();
+   m_obj->data.energy = energy;  m_obj->data.PDG = PDG;
+}
+
+
+ConstExampleMC::ConstExampleMC(const ConstExampleMC& other) : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleMC& ConstExampleMC::operator=(const ConstExampleMC& other) {
+  if ( m_obj != nullptr) m_obj->release();
+  m_obj = other.m_obj;
+  return *this;
+}
+
+ConstExampleMC::ConstExampleMC(ExampleMCObj* obj) : m_obj(obj) {
+  if(m_obj != nullptr)
+    m_obj->acquire();
+}
+
+ConstExampleMC ConstExampleMC::clone() const {
+  return {new ExampleMCObj(*m_obj)};
+}
+
+ConstExampleMC::~ConstExampleMC(){
+  if ( m_obj != nullptr) m_obj->release();
+}
+
+  const double& ConstExampleMC::energy() const { return m_obj->data.energy; }
+  const int& ConstExampleMC::PDG() const { return m_obj->data.PDG; }
+
+std::vector<ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {
+  auto ret_value = m_obj->m_parents->begin();
+  std::advance(ret_value, m_obj->data.parents_begin);
+  return ret_value;
+}
+
+std::vector<ConstExampleMC>::const_iterator ConstExampleMC::parents_end() const {
+  auto ret_value = m_obj->m_parents->begin();
+  std::advance(ret_value, m_obj->data.parents_end-1);
+  return ++ret_value;
+}
+
+unsigned int ConstExampleMC::parents_size() const {
+  return (m_obj->data.parents_end-m_obj->data.parents_begin);
+}
+
+ConstExampleMC ConstExampleMC::parents(unsigned int index) const {
+  if (parents_size() > index) {
+    return m_obj->m_parents->at(m_obj->data.parents_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
+std::vector<ConstExampleMC>::const_iterator ConstExampleMC::daughters_begin() const {
+  auto ret_value = m_obj->m_daughters->begin();
+  std::advance(ret_value, m_obj->data.daughters_begin);
+  return ret_value;
+}
+
+std::vector<ConstExampleMC>::const_iterator ConstExampleMC::daughters_end() const {
+  auto ret_value = m_obj->m_daughters->begin();
+  std::advance(ret_value, m_obj->data.daughters_end-1);
+  return ++ret_value;
+}
+
+unsigned int ConstExampleMC::daughters_size() const {
+  return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
+}
+
+ConstExampleMC ConstExampleMC::daughters(unsigned int index) const {
+  if (daughters_size() > index) {
+    return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
+
+
+bool  ConstExampleMC::isAvailable() const {
+  if (m_obj != nullptr) {
+    return true;
+  }
+  return false;
+}
+
+const podio::ObjectID ConstExampleMC::getObjectID() const {
+  if (m_obj !=nullptr){
+    return m_obj->id;
+  }
+  return podio::ObjectID{-2,-2};
+}
+
+bool ConstExampleMC::operator==(const ExampleMC& other) const {
+     return (m_obj==other.m_obj);
+}
+
+//bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
+//  if( p1.m_containerID == p2.m_containerID ) {
+//    return p1.m_index < p2.m_index;
+//  } else {
+//    return p1.m_containerID < p2.m_containerID;
+//  }
+//}
+
+

--- a/tests/src/ExampleMCObj.cc
+++ b/tests/src/ExampleMCObj.cc
@@ -1,0 +1,28 @@
+#include "ExampleMCObj.h"
+#include "ExampleMC.h"
+#include "ExampleMC.h"
+
+
+
+ExampleMCObj::ExampleMCObj() :
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_parents(new std::vector<ConstExampleMC>()), m_daughters(new std::vector<ConstExampleMC>())
+{ }
+
+ExampleMCObj::ExampleMCObj(const podio::ObjectID id, ExampleMCData data) :
+    ObjBase{id,0}, data(data)
+{ }
+
+ExampleMCObj::ExampleMCObj(const ExampleMCObj& other) :
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
+    , data(other.data), m_parents(new std::vector<ConstExampleMC>(*(other.m_parents))), m_daughters(new std::vector<ConstExampleMC>(*(other.m_daughters)))
+{ }
+
+ExampleMCObj::~ExampleMCObj() {
+  if (id.index == podio::ObjectID::untracked) {
+    delete m_parents;
+    delete m_daughters;
+
+  }
+
+}
+

--- a/tests/src/ExampleReferencingType.cc
+++ b/tests/src/ExampleReferencingType.cc
@@ -50,8 +50,11 @@ std::vector<ConstExampleCluster>::const_iterator ExampleReferencingType::Cluster
 
 std::vector<ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
-  std::advance(ret_value, m_obj->data.Clusters_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.Clusters==0
+//  std::advance(ret_value, m_obj->data.Clusters_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.Clusters_end);
+  return ret_value;
 }
 
 void ExampleReferencingType::addClusters(ConstExampleCluster component) {
@@ -77,8 +80,11 @@ std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType:
 
 std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_end() const {
   auto ret_value = m_obj->m_Refs->begin();
-  std::advance(ret_value, m_obj->data.Refs_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.Refs==0
+//  std::advance(ret_value, m_obj->data.Refs_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.Refs_end);
+  return ret_value;
 }
 
 void ExampleReferencingType::addRefs(ConstExampleReferencingType component) {

--- a/tests/src/ExampleWithVectorMember.cc
+++ b/tests/src/ExampleWithVectorMember.cc
@@ -50,8 +50,11 @@ std::vector<int>::const_iterator ExampleWithVectorMember::count_begin() const {
 
 std::vector<int>::const_iterator ExampleWithVectorMember::count_end() const {
   auto ret_value = m_obj->m_count->begin();
-  std::advance(ret_value, m_obj->data.count_end-1);
-  return ++ret_value;
+//fg: this code fails if m_obj->data.count==0
+//  std::advance(ret_value, m_obj->data.count_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.count_end);
+  return ret_value;
 }
 
 void ExampleWithVectorMember::addcount(int component) {

--- a/tests/src/selection.xml
+++ b/tests/src/selection.xml
@@ -85,6 +85,36 @@
             <field name="m_registry" transient="true"/>
             <field name="m_container" transient="true"/>
           </class>
+          <class name="std::vector<ExampleMCData>" />
+
+          <class name="ExampleMCData">
+            <field name="m_registry" transient="true"/>
+            <field name="m_container" transient="true"/>
+          </class>
+          <class name="std::vector<ExampleMC>" />
+
+          <class name="ExampleMC">
+            <field name="m_registry" transient="true"/>
+            <field name="m_container" transient="true"/>
+          </class>
+          <class name="std::vector<ConstExampleMC>" />
+
+          <class name="ConstExampleMC">
+            <field name="m_registry" transient="true"/>
+            <field name="m_container" transient="true"/>
+          </class>
+          <class name="std::vector<ExampleMCCollection>" />
+
+          <class name="ExampleMCCollection">
+            <field name="m_registry" transient="true"/>
+            <field name="m_container" transient="true"/>
+          </class>
+          <class name="std::vector<ExampleMCObj>" />
+
+          <class name="ExampleMCObj">
+            <field name="m_registry" transient="true"/>
+            <field name="m_container" transient="true"/>
+          </class>
           <class name="std::vector<EventInfoData>" />
 
           <class name="EventInfoData">

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -1,5 +1,6 @@
 // Data model
 #include "EventInfoCollection.h"
+#include "ExampleMCCollection.h"
 #include "ExampleHitCollection.h"
 #include "ExampleClusterCollection.h"
 #include "ExampleReferencingTypeCollection.h"
@@ -26,6 +27,7 @@ int main(){
   auto writer = podio::ROOTWriter("example.root", &store);
 
   auto& info       = store.create<EventInfoCollection>("info");
+  auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
   auto& hits       = store.create<ExampleHitCollection>("hits");
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
   auto& refs       = store.create<ExampleReferencingTypeCollection>("refs");
@@ -37,6 +39,7 @@ int main(){
   auto& namesprels = store.create<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   writer.registerForWrite<EventInfoCollection>("info");
+  writer.registerForWrite<ExampleMCCollection>("mcparticles");
   writer.registerForWrite<ExampleHitCollection>("hits");
   writer.registerForWrite<ExampleClusterCollection>("clusters");
   writer.registerForWrite<ExampleReferencingTypeCollection>("refs");
@@ -48,7 +51,7 @@ int main(){
   writer.registerForWrite<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   writer.registerForWrite<ExampleWithStringCollection>("strings");
 
-  unsigned nevents=2000;
+  unsigned nevents=1;//2000;
 
   for(unsigned i=0; i<nevents; ++i) {
     if(i % 1000 == 0) {
@@ -63,6 +66,77 @@ int main(){
 
     hits.push_back(hit1);
     hits.push_back(hit2);
+
+    // ---- add some MC particles ----
+    auto mcp0 = ExampleMC();
+    auto mcp1 = ExampleMC();
+    auto mcp2 = ExampleMC();
+    auto mcp3 = ExampleMC();
+    auto mcp4 = ExampleMC();
+    auto mcp5 = ExampleMC();
+    auto mcp6 = ExampleMC();
+    auto mcp7 = ExampleMC();
+    auto mcp8 = ExampleMC();
+    auto mcp9 = ExampleMC();
+
+    mcps.push_back( mcp0 ) ;
+    mcps.push_back( mcp1 ) ;
+    mcps.push_back( mcp2 ) ;
+    mcps.push_back( mcp3 ) ;
+    mcps.push_back( mcp4 ) ;
+    mcps.push_back( mcp5 ) ;
+    mcps.push_back( mcp6 ) ;
+    mcps.push_back( mcp7 ) ;
+    mcps.push_back( mcp8 ) ;
+    mcps.push_back( mcp9 ) ;
+
+    // --- add some daughter relations
+    auto p = ExampleMC();
+    auto d = ExampleMC();
+ 
+    p = mcps[0] ; 
+    p.adddaughters( mcps[2] ) ;
+    p.adddaughters( mcps[3] ) ;
+    p.adddaughters( mcps[4] ) ;
+    p.adddaughters( mcps[5] ) ;
+    p = mcps[1] ; 
+    p.adddaughters( mcps[2] ) ;
+    p.adddaughters( mcps[3] ) ;
+    p.adddaughters( mcps[4] ) ;
+    p.adddaughters( mcps[5] ) ;
+    p = mcps[2] ; 
+    p.adddaughters( mcps[6] ) ;
+    p.adddaughters( mcps[7] ) ;
+    p.adddaughters( mcps[8] ) ;
+    p.adddaughters( mcps[9] ) ;
+    p = mcps[3] ; 
+    p.adddaughters( mcps[6] ) ;
+    p.adddaughters( mcps[7] ) ;
+    p.adddaughters( mcps[8] ) ;
+    p.adddaughters( mcps[9] ) ;
+
+    //--- now fix the parent relations
+    for( unsigned j=0,N=mcps.size();j<N;++j){
+      p = mcps[j] ; 
+      for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
+	int dIndex = it->getObjectID().index ;
+	d = mcps[ dIndex ] ;
+	d.addparents( p ) ;
+      }
+    }
+    //-------- print relations for debugging:
+    for( auto p : mcps ){
+      std::cout << " particle " << p.getObjectID().index << " has daughters: " ;
+      for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
+	std::cout << " " << it->getObjectID().index ;
+      }
+      std::cout << "  and parents: " ;
+      for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
+	std::cout << " " << it->getObjectID().index ;
+      }
+      std::cout << std::endl ;
+    }
+    //-------------------------------
 
     auto cluster  = ExampleCluster();
     auto clu0  = ExampleCluster();


### PR DESCRIPTION
added a use case for storing two relations to the same class inside one collection
 - there is a bug that prevents the relations from being restored correctly:

   zitpcx16946:build gaede$ ./tests/write

start processing

processing event 0

 particle 0 has daughters:  2 3 4 5  and parents:

 particle 1 has daughters:  2 3 4 5  and parents:

 particle 2 has daughters:  6 7 8 9  and parents:  0 1

 particle 3 has daughters:  6 7 8 9  and parents:  0 1

 particle 4 has daughters:   and parents:  0 1

 particle 5 has daughters:   and parents:  0 1

 particle 6 has daughters:   and parents:  2 3

 particle 7 has daughters:   and parents:  2 3

 particle 8 has daughters:   and parents:  2 3

 particle 9 has daughters:   and parents:  2 3

zitpcx16946:build gaede$ ./tests/read

reading event 0

  Referenced hit has an energy of 23

 particle 0 daughters:  2 3 4 5  and parents:

 particle 1 daughters:  2 3 4 5  and parents:

 particle 2 daughters:  2 3 4 5  and parents:  0 1

 particle 3 daughters:  2 3 4 5  and parents:  0 1

 particle 4 daughters:   and parents:  0 1

 particle 5 daughters:   and parents:  0 1

 particle 6 daughters:   and parents:  0 1

 particle 7 daughters:   and parents:  0 1

 particle 8 daughters:   and parents:  0 1

 particle 9 daughters:   and parents:  0 1

