### PR TITLE
Some convenience functions for the readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ set( podio_VERSION_MINOR 1 )
 set( podio_VERSION_PATCH 0 )
 set( podio_VERSION "${podio_VERSION_MAJOR}.${podio_VERSION_MINOR}" )
 
-set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(APPLE)

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -63,6 +63,8 @@ namespace podio {
 
     CollectionIDTable* getCollectionIDTable(){return m_table;};
 
+    virtual bool isValid() const final;
+
   private:
 
     /// get the collection of given name; returns true if successfull

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -28,6 +28,8 @@ class IReader {
     /// Get CollectionIDTable of read-in data
     virtual CollectionIDTable* getCollectionIDTable() = 0;
     //TODO: decide on smart-pointers for passing of objects
+    /// Check if reader is valid
+    virtual bool isValid() const = 0;
 };
 
 } // namespace

--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -24,6 +24,9 @@ public:
   /// get number of entries in the tree
   unsigned getEntries() const;
 
+  bool isValid() const {return m_reader.isValid();}
+  void close() {m_reader.closeFile();}
+
  private:
   podio::ROOTReader m_reader;
   podio::EventStore m_store;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -36,7 +36,7 @@ class ROOTReader : public IReader {
     ROOTReader() : m_eventNumber(0) {}
     ~ROOTReader();
     void openFile(const std::string& filename);
-    void closeFile(){};
+    void closeFile();
 
     /// Read all collections requested
     void readEvent();
@@ -56,6 +56,9 @@ class ROOTReader : public IReader {
 
     /// Preparing to read a given event
     void goToEvent(unsigned evnum);
+
+    /// Check if TFile is valid
+    virtual bool isValid() const;
 
   private:
 

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -74,7 +74,7 @@ class EventStore(object):
 
     def __exit__(self, exception_type, exception_val, trace):
         for store in self.stores:
-            store.close()
+            store[1].close()
 
     def __iter__(self):
         '''iterate on events in the tree.

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -59,12 +59,22 @@ class EventStore(object):
         coll.__getitem__ = getitem
         return coll
 
+    def isValid(self):
+        return self.current_store is not None and self.current_store.isValid()
+
     # def __getattr__(self, name):
     #     '''missing attributes are taken from self.current_store'''
     #     if name != 'current_store':
     #         return getattr(self.current_store, name)
     #     else:
     #         return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_val, trace):
+        for store in self.stores:
+            store.close()
 
     def __iter__(self):
         '''iterate on events in the tree.

--- a/python/test_EventStore.py
+++ b/python/test_EventStore.py
@@ -98,6 +98,12 @@ class EventStoreTestCase(unittest.TestCase):
         # so its event number should be 0.
         self.assertEqual(self.store[2000].get("info")[0].Number(), 0)
 
+    def test_context_managers(self):
+        with EventStore([self.filename]) as store:
+            self.assertTrue(len(store) >= 0)
+            self.assertTrue(store.isValid())
+
+
 if __name__ == "__main__":
     from ROOT import gSystem
     from subprocess import call

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -38,6 +38,10 @@ namespace podio {
     return success;
   }
 
+  bool EventStore::isValid() const {
+    return m_reader->isValid();
+  }
+
   bool EventStore::doGet(const std::string& name, CollectionBase*& collection, bool setReferences) const {
     auto result = std::find_if(begin(m_collections), end(m_collections),
                                [name](const CollPair& item)->bool { return name==item.first; }

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -85,6 +85,10 @@ namespace podio {
     readCollectionIDTable();
   }
 
+  void ROOTReader::closeFile() {
+    m_file->Close();
+  }
+
   void ROOTReader::readEvent(){
     m_eventTree->GetEntry();
     // first prepare all collections in memory...
@@ -96,6 +100,9 @@ namespace podio {
   //    inputs.first->setReferences(m_registry);
 
   //  }
+  }
+  bool ROOTReader::isValid() const {
+    return m_file->IsOpen() && !m_file->IsZombie();
   }
 
   ROOTReader::~ROOTReader() {

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -51,7 +51,7 @@ int main(){
   writer.registerForWrite<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   writer.registerForWrite<ExampleWithStringCollection>("strings");
 
-  unsigned nevents=1;//2000;
+  unsigned nevents = 2000;
 
   for(unsigned i=0; i<nevents; ++i) {
     if(i % 1000 == 0) {
@@ -93,23 +93,23 @@ int main(){
     // --- add some daughter relations
     auto p = ExampleMC();
     auto d = ExampleMC();
- 
-    p = mcps[0] ; 
+
+    p = mcps[0] ;
     p.adddaughters( mcps[2] ) ;
     p.adddaughters( mcps[3] ) ;
     p.adddaughters( mcps[4] ) ;
     p.adddaughters( mcps[5] ) ;
-    p = mcps[1] ; 
+    p = mcps[1] ;
     p.adddaughters( mcps[2] ) ;
     p.adddaughters( mcps[3] ) ;
     p.adddaughters( mcps[4] ) ;
     p.adddaughters( mcps[5] ) ;
-    p = mcps[2] ; 
+    p = mcps[2] ;
     p.adddaughters( mcps[6] ) ;
     p.adddaughters( mcps[7] ) ;
     p.adddaughters( mcps[8] ) ;
     p.adddaughters( mcps[9] ) ;
-    p = mcps[3] ; 
+    p = mcps[3] ;
     p.adddaughters( mcps[6] ) ;
     p.adddaughters( mcps[7] ) ;
     p.adddaughters( mcps[8] ) ;
@@ -117,7 +117,7 @@ int main(){
 
     //--- now fix the parent relations
     for( unsigned j=0,N=mcps.size();j<N;++j){
-      p = mcps[j] ; 
+      p = mcps[j] ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
 	int dIndex = it->getObjectID().index ;
 	d = mcps[ dIndex ] ;


### PR DESCRIPTION
- Adding a way to check if the file was opened correctly by the reader (needed for more sensible output in FCCSW tests)
- Implemented ROOTReader::closeFile
- Adding contexts for the Py-EventStore to allow more pythonic syntax:
```
with EventStore([filename]) as store:
    store.isValid()
```